### PR TITLE
Fix return type for formatNumber

### DIFF
--- a/src/utils/formatters/numbers/index.ts
+++ b/src/utils/formatters/numbers/index.ts
@@ -4,7 +4,7 @@ export function formatPhoneNumberForWhatsApp(value: string): string {
     return cleanValue
 }
 
-export function formatNumber(value: string) {
+export function formatNumber(value: string): string {
     value = value.replace(/\D/g, '')
     return value
 }


### PR DESCRIPTION
## Summary
- add `string` return type for `formatNumber`

## Testing
- `npm run build` *(fails: tsup not found)*

------
https://chatgpt.com/codex/tasks/task_e_68478ee62388832f96078cec9784bba4